### PR TITLE
Bump Cargo.toml version to 0.21.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license-file = "LICENSE"
 name = "webpki"
 readme = "README.md"
 repository = "https://github.com/briansmith/webpki"
-version = "0.21.3"
+version = "0.21.4"
 
 include = [
     "Cargo.toml",


### PR DESCRIPTION
Upstream [has released version 0.21.4 to crates.io][1] but the
`Cargo.toml` version in the repository [hasn't been updated][2].
However, `rustls` now depends on ^0.21.4 on its `main` branch, so a git
dependency on the latest `rustls` doesn't compile with our fork.

This commit updates the `Cargo.toml` version to 0.21.4 to match
upstream.

See also briansmith#150

[1]: https://crates.io/crates/webpki/0.21.4
[2]: https://github.com/briansmith/webpki/blob/2d32895b609ac3594bcdd75d6e97c78f4f184167/Cargo.toml#L25

Signed-off-by: Eliza Weisman <eliza@buoyant.io>